### PR TITLE
Create server which handles a shortlink, extracts it, and echos it back

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/karlcaga/go-psql-golinks
+
+go 1.23.1

--- a/golinks.go
+++ b/golinks.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("GET /{shortlink}", handleShortLink)
+	http.HandleFunc("GET /{shortlink}/", handleShortLink)
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func handleShortLink(w http.ResponseWriter, r *http.Request) {
+	shortlink := r.PathValue("shortlink")
+	fmt.Fprintf(w, "%v", shortlink)
+}


### PR DESCRIPTION
This simple HTTP server handles a URL in the form of a golink with or without a final slash. It extracts the shortlink out for future redirection to the destination URL. For now, we echo the shortlink back.